### PR TITLE
Update cc_policy.md

### DIFF
--- a/content/pages/cc_policy.md
+++ b/content/pages/cc_policy.md
@@ -11,26 +11,26 @@ TabTitle: ASF Credit Card Policy
 
 <div class="card-body">
 
-## PURPOSE
+## Purpose
 
-The Apache Software Foundation, a recognized 501(c)(3) charitable foundation, whose mission entails using sponsor funds responsibly. The ASF will, from time to time, issue organization credit cards to certain individuals for use in their roles. This policy sets out the acceptable and unacceptable uses of such credit cards.
+The Apache Software Foundation is a recognized 501(c)(3) charitable foundation whose mission entails using sponsor funds responsibly. The ASF will, from time to time, issue organization credit cards to certain individuals for use in their roles. This policy sets out the acceptable and unacceptable uses of such credit cards.
 
-## POLICIES
+## Policies
 
-*   Use of ASF-issued credit cards is a privilege, which the ASF may withdraw at any time
-*   Any credit card the ASF issues to an individual must be used for business purposes only, in conjunction with the individual's duties
-*   Expenses need to be appropriate, proportionately and statutory/in accordance with the ASF's bylaws
-*   Expenses must be for approved budget items only and any items not budgeted or outside what is typically paid for in the cardholders role must be authorized in advance by the President or Board of Directors
-*   Entertaining government officials requires prior approval by the President or Board of Directors
-*   Cash advances on credit cards require prior approval by the President or Board of Directors and usage must be documented, e.g. through receipts
-*   Personal purchases of any type are strictly prohibited
-*   The cardholder is responsible for all charges made to the card and will be held liable for any unauthorized items appearing on the credit card statement
-*   Cardholders are required to sign the "cardholder agreement" indicating they accept these terms. Individuals who do not adhere to these policies risk revocation of their credit card privileges and/or disciplinary action
-*   These terms may change in the future at which point the cardholder will be notified of the updated policies and asked to acknowledge receipt
+*   Use of ASF-issued credit cards is a privilege, which the ASF may withdraw at any time.
+*   Any credit card the ASF issues to an individual must be used for business purposes only, in conjunction with the individual's duties.
+*   Expenses need to be appropriate, proportionate and statutory/in accordance with the ASF's bylaws.
+*   Expenses must be for approved budget items only. Any items not budgeted or outside what is typically paid for in the cardholder's role must be authorized in advance by the President or Board of Directors.
+*   Using the credit card to entertain government officials requires prior approval by the President or Board of Directors.
+*   Cash advances on credit cards require prior approval by the President or Board of Directors and usage must be documented, e.g. through receipts.
+*   Personal purchases of any type are strictly prohibited.
+*   The cardholder is responsible for all charges made to the card and will be held liable for any unauthorized items appearing on the credit card statement.
+*   Cardholders are required to sign the "cardholder agreement" indicating they accept these terms. Individuals who do not adhere to these policies risk revocation of their credit card privileges and/or disciplinary action.
+*   These terms may change in the future, at which point the cardholder will be notified of the updated policies and asked to acknowledge receipt.
 
-## CARDHOLDER AGREEMENT
+## Cardholder agreement
 
-I, _____________________________, understand that improper use of the ASF-issued credit card may result in disciplinary action as well as personal liability for any improper use. I acknowledge receipt of the Credit Card Policies and confirm that I understand the terms and conditions. I agree to comply with the terms and conditions of this agreement and the Credit Card Policies for The Apache Software Foundation. As a cardholder, I agree to accept the responsibility and accountability for the protection and proper use of the card. I understand that the card is not to be used for personal purchases. If the card is used for personal purchases or for purchases for any other entity, the ASF will be entitled to reimbursement from me of such purchases. The ASF shall be entitled to pursue legal action, if required, to recover the cost of such purchases, together with costs of collection and reasonable attorney fees.
+I, _____________________________, understand that improper use of the ASF-issued credit card may result in disciplinary action as well as personal liability for any improper use. I acknowledge receipt of the Credit Card Policies and confirm that I understand the terms and conditions. I agree to comply with the terms and conditions of this agreement and the Credit Card Policies for The Apache Software Foundation. As a cardholder, I agree to accept the responsibility and accountability for the protection and proper use of the card. I understand that the card is not to be used for personal purchases. If the card is used for personal purchases or for purchases for any other entity, the ASF will be entitled to reimbursement from me for such purchases. The ASF shall be entitled to pursue legal action, if required, to recover the cost of such purchases, together with costs of collection and reasonable attorney fees.
 
 Signature ___________________________________ Date _________________ (Cardholder)
 


### PR DESCRIPTION
Suggestions from Andrew Wetmore (andreww), Editor for the Infrastructure team.

Changed all the ## titles to the style of the first one.
Line 16: the first sentence was grammatically incorrect. Have fixed it.
Lines 20-29: Adjusted the list so all elements have the same punctuation style (a period at the end of the sentence).
Line 22: proportionately => proportionate
Line 23: Adjusted to improve readability. NOTE that the second sentence contradicts the first sentence.
Line 24: Entertaining => Using the credit card to entertain
Line 29: added a comma after "future".
Line 31: cardholer => cardholder
line 33: of such purchases => for such purchases